### PR TITLE
Add new API to mockoon - get patient

### DIFF
--- a/src/assets/api/biomag.json
+++ b/src/assets/api/biomag.json
@@ -1,0 +1,77 @@
+{
+  "uuid": "7000b16d-24df-4171-af32-1dbe5c4fde2d",
+  "lastMigration": 25,
+  "name": "Biomag",
+  "endpointPrefix": "",
+  "latency": 0,
+  "port": 3001,
+  "hostname": "0.0.0.0",
+  "folders": [],
+  "routes": [
+    {
+      "uuid": "c7af5f36-9ac4-431d-b6aa-3f57e3005453",
+      "documentation": "",
+      "method": "get",
+      "endpoint": "patient",
+      "responses": [
+        {
+          "uuid": "7876fba1-eefc-42f3-bf68-34e64a0078af",
+          "body": "[\r\n  {\r\n    \"id\": \"63d7b2b46f0e3fdab33e667d\",\r\n    \"name\": \"Luann\",\r\n    \"surname\": \"Gillespie\",\r\n    \"gender\": \"female\",\r\n    \"email\": \"luanngillespie@venoflex.com\",\r\n    \"phone\": \"+1 (917) 542-3444\",\r\n    \"location\": \"Westphalia\",\r\n    \"dob\": \"05-02-1962\"\r\n  },\r\n  {\r\n    \"id\": \"63d7b2b4fddae78f492344fb\",\r\n    \"name\": \"Phoebe\",\r\n    \"surname\": \"Evans\",\r\n    \"gender\": \"female\",\r\n    \"email\": \"phoebeevans@venoflex.com\",\r\n    \"phone\": \"+1 (972) 481-2375\",\r\n    \"location\": \"Leland\",\r\n    \"dob\": \"22-03-1958\"\r\n  },\r\n  {\r\n    \"id\": \"63d7b2b4674976d728d81c65\",\r\n    \"name\": \"Vazquez\",\r\n    \"surname\": \"Dunlap\",\r\n    \"gender\": \"male\",\r\n    \"email\": \"vazquezdunlap@venoflex.com\",\r\n    \"phone\": \"+1 (836) 475-3135\",\r\n    \"location\": \"Topanga\",\r\n    \"dob\": \"22-06-2015\"\r\n  },\r\n  {\r\n    \"id\": \"63d7b2b4fbf6c0e7cf6e5aa5\",\r\n    \"name\": \"Conrad\",\r\n    \"surname\": \"Hubbard\",\r\n    \"gender\": \"male\",\r\n    \"email\": \"conradhubbard@venoflex.com\",\r\n    \"phone\": \"+1 (987) 400-3809\",\r\n    \"location\": \"Roeville\",\r\n    \"dob\": \"22-08-2001\"\r\n  },\r\n  {\r\n    \"id\": \"63d7b2b43a3629bb7b6dfbec\",\r\n    \"name\": \"Berg\",\r\n    \"surname\": \"Franks\",\r\n    \"gender\": \"male\",\r\n    \"email\": \"bergfranks@venoflex.com\",\r\n    \"phone\": \"+1 (990) 553-2832\",\r\n    \"location\": \"Garfield\",\r\n    \"dob\": \"17-01-2008\"\r\n  }\r\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true
+        }
+      ],
+      "enabled": true,
+      "responseMode": null
+    }
+  ],
+  "rootChildren": [
+    {
+      "type": "route",
+      "uuid": "c7af5f36-9ac4-431d-b6aa-3f57e3005453"
+    }
+  ],
+  "proxyMode": false,
+  "proxyHost": "",
+  "proxyRemovePrefix": false,
+  "tlsOptions": {
+    "enabled": false,
+    "type": "CERT",
+    "pfxPath": "",
+    "certPath": "",
+    "keyPath": "",
+    "caPath": "",
+    "passphrase": ""
+  },
+  "cors": true,
+  "headers": [
+    {
+      "key": "Content-Type",
+      "value": "application/json"
+    }
+  ],
+  "proxyReqHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "proxyResHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "data": []
+}


### PR DESCRIPTION
new api have been added
GET /patient

to test it: 
- install mockoon, 
- load environment in mockoon, file `..src/assets/api/biomag.json` 
![image](https://user-images.githubusercontent.com/11686968/215483953-e4fc650e-2647-4697-bc5f-deed1651019a.png)

- press play in mockoon, you should be able to go to http:\\localhost:3001\patient and see dummy data for the patients

![image](https://user-images.githubusercontent.com/11686968/215484335-26d18fbf-a6c3-4974-96d9-ce18373cb29b.png)

the dummy data has been generated with this [tool](https://json-generator.com/)
